### PR TITLE
Add pvc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ abstraction layer it adds complexity.
 ## Roadmap
 
 - [x] --save to file(s)
-- [ ] Make installable
-- [ ] Support for volumes
+- [x] Make installable
+- [x] Support for volumes
 - [ ] Support for secrets
 - [ ] Support for annotations

--- a/examples/application-full.yaml
+++ b/examples/application-full.yaml
@@ -20,5 +20,5 @@ environment:
 
 # Volumes to mount
 volumes:
-  - /path/to/mount/volume # Requests 1Gi by default
+  - /path/to/mount/volume: # Requests 1Gi by default
   - /path/to/mount/volume: 24Gi

--- a/examples/application-full.yaml
+++ b/examples/application-full.yaml
@@ -1,5 +1,7 @@
 # A name that identifies your app
 name: my-app
+# A namespace where your app will live
+namespace: my-namespace
 # An URI for your app Docker image
 image: docker.pkg.github.com/my-org/my-repo/my-package
 # The version of your app which is available as an image

--- a/pkg/api/application.go
+++ b/pkg/api/application.go
@@ -4,6 +4,8 @@ import "sigs.k8s.io/yaml"
 
 type Application struct {
 	Name string
+	Namespace string
+	
 	Image string
 	Version string
 	ImagePullSecret string

--- a/pkg/api/application.go
+++ b/pkg/api/application.go
@@ -16,6 +16,7 @@ type Application struct {
 	Replicas int32
 	
 	Environment map[string]string
+	Volumes []map[string]string
 }
 
 func ParseApplication(raw string) (Application, error) {

--- a/pkg/api/deployment.go
+++ b/pkg/api/deployment.go
@@ -7,8 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
-	deploymentTemplate = v1.Deployment{
+func generateDefaultDeployment() v1.Deployment {
+	return v1.Deployment{
 		TypeMeta:   metav1.TypeMeta{
 			Kind:       "Deployment",
 			APIVersion: "apps/v1",
@@ -28,7 +28,7 @@ var (
 			},
 		},
 	}
-)
+}
 
 func CreateContainers(app Application) []v12.Container {
 	var envVars []v12.EnvVar
@@ -78,7 +78,7 @@ func CreateVolumes(app Application) []v12.Volume {
 }
 
 func CreateDeployment(app Application) (v1.Deployment, error) {
-	deployment := deploymentTemplate
+	deployment := generateDefaultDeployment()
 	
 	deployment.ObjectMeta.Name = app.Name
 	deployment.ObjectMeta.Namespace = app.Namespace

--- a/pkg/api/deployment.go
+++ b/pkg/api/deployment.go
@@ -49,6 +49,7 @@ func CreateDeployment(app Application) (v1.Deployment, error) {
 	deployment := deploymentTemplate
 	
 	deployment.ObjectMeta.Name = app.Name
+	deployment.ObjectMeta.Namespace = app.Namespace
 	
 	if app.Replicas == 0 {
 		app.Replicas = 1

--- a/pkg/api/expansion.go
+++ b/pkg/api/expansion.go
@@ -17,6 +17,22 @@ func Expand(w io.Writer, app Application, podonly bool) error {
 			return err
 		}
 	}
+	
+	if len(app.Volumes) != 0 {
+		for _, volume := range app.Volumes {
+			for path, size := range volume {
+				volume, err := CreatePersistentVolume(app, path, size)
+				if err != nil {
+					return err
+				}
+				
+				err = WriteResource(w, volume)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
 
 	if app.Url != "" {
 		ingress, err := CreateIngress(app)

--- a/pkg/api/ingress.go
+++ b/pkg/api/ingress.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-var (
-	ingressTemplate = v1.Ingress{
+func generateDefaultIngress() v1.Ingress {
+	return v1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
 			APIVersion: "networking.k8s.io/v1beta1",
@@ -23,7 +23,7 @@ var (
 			Rules: []v1.IngressRule{{}},
 		},
 	}
-)
+}
 
 func CreateIngress(app Application) (v1.Ingress, error) {
 	hostUrl, err := url.Parse(app.Url)
@@ -31,7 +31,7 @@ func CreateIngress(app Application) (v1.Ingress, error) {
 		return v1.Ingress{}, err
 	}
 	
-	ingress := ingressTemplate
+	ingress := generateDefaultIngress()
 	ingress.ObjectMeta.Namespace = app.Namespace
 	
 	ingress.ObjectMeta.Name = app.Name

--- a/pkg/api/ingress.go
+++ b/pkg/api/ingress.go
@@ -32,6 +32,7 @@ func CreateIngress(app Application) (v1.Ingress, error) {
 	}
 	
 	ingress := ingressTemplate
+	ingress.ObjectMeta.Namespace = app.Namespace
 	
 	ingress.ObjectMeta.Name = app.Name
 	

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -30,5 +30,7 @@ func CreatePod(app Application) (v1.Pod, error) {
 		pod.Spec.ImagePullSecrets = []v1.LocalObjectReference{{Name: app.ImagePullSecret}}
 	}
 	
+	pod.Spec.Volumes = CreateVolumes(app)
+	
 	return pod, nil
 }

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -22,6 +22,8 @@ func CreatePod(app Application) (v1.Pod, error) {
 	pod := podTemplate
 	
 	pod.ObjectMeta.Name = app.Name
+	pod.ObjectMeta.Namespace = app.Namespace
+
 	pod.Spec.Containers = CreateContainers(app)
 	
 	if app.ImagePullSecret != "" {

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -5,8 +5,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
-	podTemplate = v1.Pod{
+func generateDefaultPod() v1.Pod {
+	return v1.Pod{
 		TypeMeta:   metav1.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
@@ -16,10 +16,10 @@ var (
 			Volumes:                       nil,
 		},
 	}
-)
+}
 
 func CreatePod(app Application) (v1.Pod, error) {
-	pod := podTemplate
+	pod := generateDefaultPod()
 	
 	pod.ObjectMeta.Name = app.Name
 	pod.ObjectMeta.Namespace = app.Namespace

--- a/pkg/api/pvc.go
+++ b/pkg/api/pvc.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+var (
+	volumeTemplate = v1.PersistentVolume{
+		TypeMeta:   metav1.TypeMeta{
+			Kind:       "PersistentVolumeClaim",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       v1.PersistentVolumeSpec{
+			Capacity:  					   v1.ResourceList{
+				v1.ResourceRequestsStorage: resource.Quantity{
+					Format: "1Gi",
+				},
+			},
+			AccessModes:                   []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+		},
+	}
+)
+
+func CreatePVCName(app Application, path string) string {
+	cleanPath := strings.Replace(path, "/", "", -1)
+
+	return fmt.Sprintf("%s-%s", app.Name, cleanPath)
+}
+
+func CreatePersistentVolume(app Application, path string, size string) (v1.PersistentVolume, error) {
+	volume := volumeTemplate
+	
+	volume.ObjectMeta.Name = CreatePVCName(app, path)
+	volume.ObjectMeta.Namespace = app.Namespace
+	
+	capacity, err := createStorageCapacity(size)
+	if err != nil {
+		return v1.PersistentVolume{}, err
+	}
+	volume.Spec.Capacity = capacity
+	
+	return volume, nil
+}
+
+func createStorageCapacity(requestSize string) (v1.ResourceList, error) {
+	quantity, err := resource.ParseQuantity("1Gi")
+	if requestSize != "" {
+		quantity, err = resource.ParseQuantity(requestSize)
+		
+		if err != nil {
+			return nil, err
+		}
+	}
+	
+	return v1.ResourceList{
+		v1.ResourceRequestsStorage: quantity,
+	}, nil
+}

--- a/pkg/api/pvc.go
+++ b/pkg/api/pvc.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-var (
-	volumeTemplate = v1.PersistentVolume{
+func generateDefaultPVC() v1.PersistentVolume {
+	return v1.PersistentVolume{
 		TypeMeta:   metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
 			APIVersion: "v1",
@@ -24,7 +24,7 @@ var (
 			AccessModes:                   []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
 		},
 	}
-)
+}
 
 func CreatePVCName(app Application, path string) string {
 	cleanPath := strings.Replace(path, "/", "", -1)
@@ -33,7 +33,7 @@ func CreatePVCName(app Application, path string) string {
 }
 
 func CreatePersistentVolume(app Application, path string, size string) (v1.PersistentVolume, error) {
-	volume := volumeTemplate
+	volume := generateDefaultPVC()
 	
 	volume.ObjectMeta.Name = CreatePVCName(app, path)
 	volume.ObjectMeta.Namespace = app.Namespace

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -22,7 +22,9 @@ var (
 
 func CreateService(app Application) (v1.Service, error) {
 	service := serviceTemplate
+	
 	service.ObjectMeta.Name = app.Name
+	service.ObjectMeta.Namespace = app.Namespace
 
 	service.Spec.Selector = map[string]string{
 		"app": app.Name,

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var (
-	serviceTemplate = v1.Service{
+func generateDefaultService() v1.Service {
+	return v1.Service{
 		TypeMeta:   metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
@@ -18,10 +18,10 @@ var (
 			Type: "ClusterIP",
 		},
 	}
-)
+}
 
 func CreateService(app Application) (v1.Service, error) {
-	service := serviceTemplate
+	service := generateDefaultService()
 	
 	service.ObjectMeta.Name = app.Name
 	service.ObjectMeta.Namespace = app.Namespace


### PR DESCRIPTION
One can now define volumes!

To test:
1. `cat examples/application-full.yaml | ./kaex expand`
2. Verify that a PVC is defined and that the volumes and volumeMounts in the deployment/pod spec is defined correctly

Tip: delete the url and port fields in the application-full.yaml so that Kaex wont create an ingress and a service for cleaner output