### PR TITLE
✅ Add ability to declare a custom example to scaffold

### DIFF
--- a/pkg/api/scaffolding.go
+++ b/pkg/api/scaffolding.go
@@ -15,11 +15,11 @@ const (
 )
 
 func FetchMinimalExample(w io.Writer) error {
-	name := "application-minimal.yaml"
+	exampleFileName := "application-minimal.yaml"
 
-	err := fetchExample(w, name)
+	err := fetchExample(w, exampleFileName)
 	if err != nil {
-		err = fmt.Errorf("unable to fetch %s: %w", name, err)
+		err = fmt.Errorf("unable to fetch %s: %w", exampleFileName, err)
 
 		return err
 	}
@@ -28,11 +28,11 @@ func FetchMinimalExample(w io.Writer) error {
 }
 
 func FetchFullExample(w io.Writer) error {
-	name := "application-full.yaml"
+	exampleFileName := "application-full.yaml"
 
-	err := fetchExample(w, name)
+	err := fetchExample(w, exampleFileName)
 	if err != nil {
-		err = fmt.Errorf("unable to fetch %s: %w", name, err)
+		err = fmt.Errorf("unable to fetch %s: %w", exampleFileName, err)
 
 		return err
 	}

--- a/pkg/api/scaffolding.go
+++ b/pkg/api/scaffolding.go
@@ -5,26 +5,76 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"path"
 	"time"
 )
 
+const (
+	REPO_EXAMPLE_BASE_URL = "https://raw.githubusercontent.com/oslokommune/kaex/master/examples"
+)
+
 func FetchMinimalExample(w io.Writer) error {
-	url := "https://raw.githubusercontent.com/deifyed/kaex/master/examples/application-minimal.yaml"
-	
-	example, err := fetchExample(url)
+	name := "application-minimal.yaml"
+
+	err := fetchExample(w, name)
 	if err != nil {
+		err = fmt.Errorf("unable to fetch %s: %w", name, err)
+
 		return err
-	} 
-	
-	fmt.Fprintf(w, example)
-	
+	}
+
 	return nil
 }
 
 func FetchFullExample(w io.Writer) error {
-	url := "https://raw.githubusercontent.com/deifyed/kaex/master/examples/application-full.yaml"
+	name := "application-full.yaml"
 
-	example, err := fetchExample(url)
+	err := fetchExample(w, name)
+	if err != nil {
+		err = fmt.Errorf("unable to fetch %s: %w", name, err)
+
+		return err
+	}
+
+	return nil
+}
+
+func fetchLocalExample(name string) (string, error) {
+	configPath, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	targetPath := path.Join(configPath, fmt.Sprintf("kaex/%s", name))
+	_, err = os.Stat(targetPath)
+	if err != nil {
+		err = fmt.Errorf("no such file/path \"%s\": %w", targetPath, err)
+
+		return "", err
+	}
+
+	data, err := ioutil.ReadFile(targetPath)
+	if err != nil {
+		err = fmt.Errorf("error while reading file: %w", err)
+
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func fetchExample(w io.Writer, name string) error {
+	example, err := fetchLocalExample(name)
+	if err == nil {
+		fmt.Fprintf(w, example)
+
+		return nil
+	}
+
+	url := fmt.Sprintf("%s/%s", REPO_EXAMPLE_BASE_URL, name)
+
+	example, err = fetchURL(url)
 	if err != nil {
 		return err
 	}
@@ -34,7 +84,7 @@ func FetchFullExample(w io.Writer) error {
 	return nil
 }
 
-func fetchExample(url string) (string, error) {
+func fetchURL(url string) (string, error) {
 	spaceClient := http.Client{
 		Timeout: 2 * time.Second,
 	}


### PR DESCRIPTION
With this PR one can now declare a local version that `kaex initialize` will use instead of fetching a remote one.

To test:
1. `mkdir -p ~/.config/kaex && cd ~/.config/kaex`
2. `./kaex init >> ~/.config/kaex/application-minimal.yaml`
3. Edit the ~/.config/kaex/application-minimal.yaml to your liking. Maybe set a default imagePullSecret
4. Run `./kaex init` and verify that the output contains your adjustment