### PR TITLE
🐛 README.md: Add expand arg to kaex command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For now;
 ## Usage
 1. `kaex init > application.yaml`
 2. Edit application.yaml to suit your app
-3. `cat application.yaml | kaex | kubectl apply -f`
+3. `cat application.yaml | kaex expand | kubectl apply -f`
 
 ## Erm. What was that three-step instructions above for?
 Sorry! I assumed you.. Never mind. I'll explain.


### PR DESCRIPTION
Using kaex as it says in the documentation doesn't work:

```bash
$ cat app.yaml | kaex 
A tool for converting a simpler application.yaml into Kubernetes resources

Usage:
  kaex [command]

Available Commands:
  expand      expands an application.yaml from stdin (default)
  help        Help about any command
  initialize  scaffolds a template application.yaml

Flags:
  -h, --help   help for kaex

Use "kaex [command] --help" for more information about a command.
```

Using `cat app.yaml | kaex expand` however, works.

