### PR TITLE
Add debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ Kayx, like "cakes"
 For now;
 1. `git clone git@github.com:oslokommune/kaex.git`
 2. `cd kaex`
-3. `make build`
-4. `make install`
+3. `make install`
 
-4a. Add `~/.local/bin` to your PATH
+P.S.: Remember to add GOBIN to your path: `export PATH=${PATH}:$(go env GOBIN)`
 
 ## Usage
 1. `kaex init > application.yaml`

--- a/cmd/kaex/init.go
+++ b/cmd/kaex/init.go
@@ -5,10 +5,16 @@ import (
 	"fmt"
 	"github.com/oslokommune/kaex/pkg/api"
 	"github.com/spf13/cobra"
+	"os"
 )
 
+type InitializeOptions struct {
+	FullExample bool
+	Debugger bool
+}
+
 var (
-	fullExample bool
+	options = &InitializeOptions{}
 	initCmd = &cobra.Command{
 		Use: "initialize",
 		Aliases: []string{"init", "i"},
@@ -17,20 +23,32 @@ var (
 		`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			var err error
-			
+
 			var buffer bytes.Buffer
-			
-			if fullExample {
+
+			if options.Debugger {
+				err = api.GenerateDebugger(&buffer)
+
+				if err != nil {
+					fmt.Fprint(os.Stderr, err)
+				} else {
+					fmt.Fprint(os.Stdout, buffer.String())
+				}
+
+				return nil
+			}
+
+			if options.FullExample {
 				err = api.FetchFullExample(&buffer)
 			} else {
 				err = api.FetchMinimalExample(&buffer)
 			}
-			
+
 			if err != nil {
 				return err
 			}
-			
-			fmt.Println(buffer.String())
+
+			fmt.Fprintln(os.Stdout, buffer.String())
 
 			return nil
 		},
@@ -38,7 +56,8 @@ var (
 )
 
 func init() {
-	initCmd.Flags().BoolVarP(&fullExample, "full", "f", false, "use full template to scaffold rather than the minimal template")
+	initCmd.Flags().BoolVarP(&options.FullExample, "full", "f", false, "use full template to scaffold rather than the minimal template")
+	initCmd.Flags().BoolVarP(&options.Debugger, "debugger", "d", false, "scaffold a debugger instance")
 
 	rootCmd.AddCommand(initCmd)
 }

--- a/kaex
+++ b/kaex
@@ -1,3 +1,0 @@
-
-
-go run cmd/kaex/* $@

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ run:
 	@go build -o build/kaex cmd/kaex/*.go
 
 install:
-	go install cmd/kaex/*.go
+	cd cmd/kaex && go install
 
 clean:
 	@rm -r ./build

--- a/makefile
+++ b/makefile
@@ -3,12 +3,11 @@
 run:
 	@go run cmd/kaex/*.go
 
-build:
+./build:
 	@go build -o build/kaex cmd/kaex/*.go
 
 install:
-	mkdir -p ~/.local/bin
-	cp ./build/kaex ~/.local/bin/kaex
+	go install cmd/kaex/*.go
 
 clean:
 	@rm -r ./build

--- a/pkg/api/scaffolding.go
+++ b/pkg/api/scaffolding.go
@@ -109,3 +109,26 @@ func fetchURL(url string) (string, error) {
 
 	return string(body), nil
 }
+
+func GenerateDebugger(writer io.Writer) error {
+	app := Application{
+		Name:            "debugger",
+		Image:           "markeijsermans/debug",
+		Version:         "kitchen-sink",
+		Replicas:        1,
+	}
+
+	pod, err := CreatePod(app)
+	if err != nil {
+		return fmt.Errorf("error creating debugger pod: %w", err)
+	}
+
+	pod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", "sleep 3600"}
+
+	err = WriteResource(writer, pod)
+	if err != nil {
+		return fmt.Errorf("error writing resource to writer: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR:
- adds scaffolding of a pod full of commonly used tools for debugging purposes
- uses go install for installation

To test;
1. Deploy the debugger with `kaex init -d | kubectl apply -f -`
2. Use with `kubectl exec -it debugger-sha -- sh`

A nice (but a tad heavy) pod for debugging purposes