### PR TITLE
✅ Add split command

### DIFF
--- a/cmd/kaex/root.go
+++ b/cmd/kaex/root.go
@@ -31,6 +31,7 @@ func Execute() error {
 
 	rootCmd.AddCommand(buildInitializeCommand(kaex))
 	rootCmd.AddCommand(buildExpandCommand(kaex))
+	rootCmd.AddCommand(buildSplitCommand(kaex))
 
 	return rootCmd.Execute()
 }

--- a/cmd/kaex/split.go
+++ b/cmd/kaex/split.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/oslokommune/kaex/pkg/api"
+	"github.com/oslokommune/kaex/pkg/extraction"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"path"
+)
+
+const splitLongHelpText = `Splits a yaml file containing multiple Kubernetes resources.
+
+Usage example:
+$ kaex split <<EOF
+apiVersion: v1
+kind: Ingress
+
+---
+apiVersion: v1
+kind: Service
+EOF
+
+$ cat file-containing-multiple-resources.yaml | kaex split
+
+Result:
+$ ls
+. .. ingress.yaml service.yaml
+`
+
+var outputDirectory string
+
+func buildSplitCommand(kaex api.Kaex) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "split",
+		Aliases: []string{"s"},
+		Short:   "split a yaml file with multiple Kubernetes resources into one file for each resource",
+		Long:    splitLongHelpText,
+		RunE: func(_ *cobra.Command, args []string) error {
+			data, err := ioutil.ReadAll(kaex.In)
+			if err != nil {
+				return fmt.Errorf("reading input: %w", err)
+			}
+
+			fs := afero.Afero{Fs: afero.NewOsFs()}
+
+			parts := bytes.Split(data, []byte("---"))
+
+			for _, part := range parts {
+				err = handlePart(fs, outputDirectory, part)
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVarP(&outputDirectory,
+		"output-directory",
+		"o",
+		"./",
+		"choose what directory Kaex should place the resource files",
+	)
+
+	return cmd
+}
+
+func handlePart(fs afero.Afero, outputDirectory string, part []byte) (err error) {
+	kind, err := extraction.ExtractKind(part)
+	if err != nil {
+		return fmt.Errorf("extracting kind: %w", err)
+	}
+
+	targetPath := path.Join(outputDirectory, fmt.Sprintf("%s.yaml", kind))
+
+	f, err := fs.Create(targetPath)
+	if err != nil {
+		return fmt.Errorf("creating new file: %w", err)
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	_, err = f.Write(part)
+	if err != nil {
+		return fmt.Errorf("writing part: %w", err)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/sebdah/goldie/v2 v2.5.3
+	github.com/spf13/afero v1.1.2
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,7 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=

--- a/pkg/extraction/api.go
+++ b/pkg/extraction/api.go
@@ -1,0 +1,26 @@
+package extraction
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+var ErrorNoMatch = errors.New("no match found for kind")
+
+var kindRetriever = regexp.MustCompile(`kind:\s(\w+)`)
+
+type Resource struct {
+	Kind string
+	Data []byte
+}
+
+func ExtractKind(data []byte) (string, error) {
+	match := kindRetriever.FindSubmatch(data)
+
+	if match == nil {
+		return "", ErrorNoMatch
+	}
+
+	return strings.ToLower(string(match[1])), nil
+}

--- a/pkg/extraction/api_test.go
+++ b/pkg/extraction/api_test.go
@@ -1,0 +1,51 @@
+package extraction
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestExtractKind(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		with       []byte
+		expectKind string
+
+		expectFail error
+	}{
+		{
+			name: "Should extract correct kind with valid input",
+
+			with: []byte("apiVersion: v1\nkind: Ingress\nmetadata:\n\tname: Test"),
+
+			expectKind: "ingress",
+			expectFail: nil,
+		},
+		{
+			name: "Should fail with ErrorNoMatch on invalid input",
+
+			with: []byte("apiVersion: v1\nmetadata:\n\tname: Test\n"),
+
+			expectFail: ErrorNoMatch,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ExtractKind(tc.with)
+
+			if tc.expectFail != nil {
+				assert.NotNil(t, err)
+				assert.True(t, errors.Is(tc.expectFail, err))
+			} else {
+				assert.Nil(t, err)
+
+				assert.Equal(t, tc.expectKind, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When expanding an `application.yaml`, `kaex` will produce the Kubernetes resources as a single file.

By piping the output from `kaex expand` into `kaex split`, `kaex` will produce one file for each resource instead